### PR TITLE
Fix TocSequenceEventImpl to get exactly the behavior from before PR #7

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/volume/TocSequenceEventImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/volume/TocSequenceEventImpl.java
@@ -145,6 +145,12 @@ class TocSequenceEventImpl implements VolumeSequence {
 						fsm.appendGroup(volumeEnd);
 					}
 				}
+				{
+					Collection<Block> volumeToc = data.filter(refToVolume(null, crh));
+					if (!volumeToc.isEmpty()) {
+						fsm.appendGroup(volumeToc);
+					}
+				}
 			} else {
 				throw new RuntimeException("Coding error");
 			}
@@ -156,11 +162,10 @@ class TocSequenceEventImpl implements VolumeSequence {
 		return null;
 	}
 
-	private Predicate<String> refToVolume(int vol, CrossReferenceHandler crh) {
+	private Predicate<String> refToVolume(Integer vol, CrossReferenceHandler crh) {
 		return refId -> {
 			Integer volNo = crh.getVolumeNumber(refId);
-			int v = volNo != null ? volNo : 1;
-			return v == vol;
+			return vol == null ? volNo == null : vol.equals(volNo);
 		};
 	}
 }


### PR DESCRIPTION
This does not change the final TOC, however it does change the intermediary ones, more precisely when some elements that are referred to by a toc-entry don’t have a volume number assigned to them yet (i.e. in the first VolumeProvider iteration and in the next iterations when not all content has been fit into the reserved volumes yet). And this in turn can result in a difference in the final result because the volume breaking algorithm is so sensitive.