### PR TITLE
Don't create empty row if marker-reference is empty after applying style

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/row/SegmentProcessor.java
+++ b/src/org/daisy/dotify/formatter/impl/row/SegmentProcessor.java
@@ -571,8 +571,11 @@ class SegmentProcessor implements SegmentProcessing {
             } else {
                 String mode = null;
                 BrailleTranslatorResult btr = toResult(spec, null);
-                CurrentResult cr = new CurrentResultImpl(spc, btr, mode);
-                return Optional.of(cr);
+                if (btr.hasNext()) { // Don't create a new row if the evaluated reference is empty
+                                     // after applying the style
+                    CurrentResult cr = new CurrentResultImpl(spc, btr, mode);
+                    return Optional.of(cr);
+                }
             }
         }
         return Optional.empty();


### PR DESCRIPTION
This change was needed to skip (to not create an empty line for) a `block` with only a `marker-reference` in it when that `marker-reference` is empty after having been translated to braille.

The use case is rather specific to Pipeline because usually when the result of resolving a marker reference is not empty, the resulting braille will also not be empty. Pipeline is a bit different because I have to jump through some hoops to get Dotify do exactly what I want. For example it is possible that a marker contains a special character (a zero-width space) that computes to an empty braille result. Or the marker can contain some actual text, but with a style that removes the text under certain conditions.

