### PR TITLE
Added functionallity to handle marking of capital letters in the same way as hyphenation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ targetCompatibility = 1.8
 // To test with snapshots, modify the version directly in the dependencies section,
 // but don't forget to change it back when you're done.
 ext.versions = [
-	'dotifyApi'		: '5.0.5',
+	'dotifyApi'		: '5.0.6-SNAPSHOT',
 	'dotifyCommon'	: '4.4.1',
 ]
 

--- a/src/org/daisy/dotify/formatter/impl/core/FormatterCoreImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/core/FormatterCoreImpl.java
@@ -354,7 +354,7 @@ public class FormatterCoreImpl extends Stack<Block> implements FormatterCore, Bl
             //list item has been used now, discard
             listItem = null;
         }
-        bl.addSegment(new TextSegment(c.toString(), p, fc.getConfiguration().isMarkingCapitalLetters()));
+        bl.addSegment(new TextSegment(c.toString(), p));
     }
 
     @Override

--- a/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
@@ -113,6 +113,7 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
     private FilterLocale locale;
     private String mode;
     private boolean hyphGlobal;
+    private boolean markCapitalLettersGlobal;
     private final Logger logger;
     private final FactoryManager fm;
     private boolean normalizeSpace = true;
@@ -147,6 +148,7 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
         this.locale = FilterLocale.parse(config.getLocale());
         this.mode = config.getTranslationMode();
         this.hyphGlobal = config.isHyphenating();
+        this.markCapitalLettersGlobal = config.isMarkingCapitalLetters();
         this.meta = new ArrayList<>();
         XMLEvent event;
         TextProperties tp = new TextProperties.Builder(
@@ -154,6 +156,7 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
         )
             .translationMode(mode)
             .hyphenate(hyphGlobal)
+            .markCapitalLetters(markCapitalLettersGlobal)
             .build();
         XMLEventIterator input;
         if (normalizeSpace) {
@@ -2075,8 +2078,14 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
     private TextProperties getTextProperties(XMLEvent event, TextProperties defaults) {
         String loc = getLang(event, defaults.getLocale());
         boolean hyph = getHyphenate(event, defaults.isHyphenating());
+        boolean markCapitalLetters = getMarkCapitalLetters(event, defaults.shouldMarkCapitalLetters());
+
         String trans = getTranslate(event, defaults.getTranslationMode());
-        return new TextProperties.Builder(loc.toString()).translationMode(trans).hyphenate(hyph).build();
+        return new TextProperties.Builder(loc.toString())
+                .translationMode(trans)
+                .hyphenate(hyph)
+                .markCapitalLetters(markCapitalLetters)
+                .build();
     }
 
     private String getLang(XMLEvent event, String locale) {
@@ -2102,6 +2111,18 @@ public class ObflParserImpl extends XMLParserBase implements ObflParser {
             }
         }
         return hyphenate;
+    }
+
+    private boolean getMarkCapitalLetters(XMLEvent event, boolean markCapitalLetters) {
+        String markCL = getAttr(event, ObflQName.ATTR_MARK_CAPITAL_LETTERS);
+        if (markCL != null) {
+            if ("".equals(markCL)) {
+                return markCapitalLettersGlobal;
+            } else {
+                return "true".equals(markCL);
+            }
+        }
+        return markCapitalLetters;
     }
 
     private String getTranslate(XMLEvent event, String translate) {

--- a/src/org/daisy/dotify/formatter/impl/obfl/ObflQName.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ObflQName.java
@@ -81,6 +81,7 @@ interface ObflQName {
 
     static final QName ATTR_XML_LANG = new QName("http://www.w3.org/XML/1998/namespace", "lang", "xml");
     static final QName ATTR_HYPHENATE = new QName("hyphenate");
+    static final QName ATTR_MARK_CAPITAL_LETTERS = new QName("mark-capital-letters");
     static final QName ATTR_TRANSLATE = new QName("translate");
     static final QName ATTR_PAGE_WIDTH = new QName("page-width");
     static final QName ATTR_PAGE_HEIGHT = new QName("page-height");

--- a/src/org/daisy/dotify/formatter/impl/segment/Evaluate.java
+++ b/src/org/daisy/dotify/formatter/impl/segment/Evaluate.java
@@ -119,7 +119,7 @@ public class Evaluate implements Segment {
 
     @Override
     public boolean shouldMarkCapitalLetters() {
-        return markCapitalLetters;
+        return props.shouldMarkCapitalLetters();
     }
 
 }

--- a/src/org/daisy/dotify/formatter/impl/segment/TextSegment.java
+++ b/src/org/daisy/dotify/formatter/impl/segment/TextSegment.java
@@ -12,14 +12,12 @@ import java.util.Optional;
 public class TextSegment implements Segment {
     private final String chars;
     private final TextProperties tp;
-    private final boolean markCapitalLetters;
     private BrailleTranslatorResult cache;
 
-    public TextSegment(String chars, TextProperties tp, boolean markCapitalLetters) {
+    public TextSegment(String chars, TextProperties tp) {
         this.chars = Objects.requireNonNull(chars);
         this.tp = Objects.requireNonNull(tp);
-        this.markCapitalLetters = markCapitalLetters;
-    }
+   }
 
     public boolean canMakeResult() {
         return cache != null;
@@ -111,7 +109,7 @@ public class TextSegment implements Segment {
 
     @Override
     public boolean shouldMarkCapitalLetters() {
-        return markCapitalLetters;
+        return tp.shouldMarkCapitalLetters();
     }
 
 }

--- a/src/org/daisy/dotify/formatter/impl/segment/TextSegment.java
+++ b/src/org/daisy/dotify/formatter/impl/segment/TextSegment.java
@@ -17,7 +17,7 @@ public class TextSegment implements Segment {
     public TextSegment(String chars, TextProperties tp) {
         this.chars = Objects.requireNonNull(chars);
         this.tp = Objects.requireNonNull(tp);
-   }
+    }
 
     public boolean canMakeResult() {
         return cache != null;

--- a/test/org/daisy/dotify/formatter/impl/row/BlockContentManagerTest.java
+++ b/test/org/daisy/dotify/formatter/impl/row/BlockContentManagerTest.java
@@ -40,7 +40,7 @@ public class BlockContentManagerTest {
         Stack<Segment> segments = new Stack<>();
         for (int i = 0; i < 6; i++) {
             segments.push(
-                new TextSegment("... ", new TextProperties.Builder("sv-SE").build(), true)
+                new TextSegment("... ", new TextProperties.Builder("sv-SE").build())
             );
         }
         RowDataProperties rdp = new RowDataProperties.Builder().firstLineIndent(1).textIndent(3).build();
@@ -80,7 +80,7 @@ public class BlockContentManagerTest {
                 .build()
         ));
         segments.push(
-            new TextSegment("...", new TextProperties.Builder("sv-SE").build(), true)
+            new TextSegment("...", new TextProperties.Builder("sv-SE").build())
         );
 
         RowDataProperties rdp = new RowDataProperties.Builder().firstLineIndent(1).textIndent(3).build();
@@ -102,11 +102,11 @@ public class BlockContentManagerTest {
             FormatterConfiguration.with("sv-SE", TranslatorType.UNCONTRACTED.toString()).build()
         );
         Stack<Segment> segments = new Stack<>();
-        segments.push(new TextSegment("... ... ...", new TextProperties.Builder("sv-SE").build(), true));
+        segments.push(new TextSegment("... ... ...", new TextProperties.Builder("sv-SE").build()));
         segments.push(new NewLineSegment());
-        segments.push(new TextSegment("...", new TextProperties.Builder("sv-SE").build(), true));
+        segments.push(new TextSegment("...", new TextProperties.Builder("sv-SE").build()));
         segments.push(new NewLineSegment());
-        segments.push(new TextSegment("...", new TextProperties.Builder("sv-SE").build(), true));
+        segments.push(new TextSegment("...", new TextProperties.Builder("sv-SE").build()));
 
         RowDataProperties rdp = new RowDataProperties.Builder().firstLineIndent(1).textIndent(3).build();
         CrossReferenceHandler refs = mock(CrossReferenceHandler.class);

--- a/test/org/daisy/dotify/formatter/impl/row/SegmentProcessorTest.java
+++ b/test/org/daisy/dotify/formatter/impl/row/SegmentProcessorTest.java
@@ -51,15 +51,15 @@ public class SegmentProcessorTest {
         TextProperties tp = new TextProperties.Builder("und").hyphenate(false).build();
         List<Segment> segments = new ArrayList<>();
         List<Segment> expecteds = new ArrayList<>();
-        t = new TextSegment("abc", tp, true);
+        t = new TextSegment("abc", tp);
         segments.add(t);
         expecteds.add(t);
         Style s = new Style("em");
         segments.add(s);
-        t = new TextSegment("def", tp, true);
+        t = new TextSegment("def", tp);
         s.add(t);
         expecteds.add(t);
-        t = new TextSegment("ghi", tp, true);
+        t = new TextSegment("ghi", tp);
         segments.add(t);
         expecteds.add(t);
         FormatterContext fc = new FormatterContext(BrailleTranslatorFactoryMaker.newInstance(), null, conf);
@@ -83,13 +83,13 @@ public class SegmentProcessorTest {
         Segment t;
         TextProperties tp = new TextProperties.Builder("und").hyphenate(false).build();
         List<Segment> segments = new ArrayList<>();
-        t = new TextSegment("abc", tp, true);
+        t = new TextSegment("abc", tp);
         segments.add(t);
         Style s = new Style("em");
         segments.add(s);
-        t = new TextSegment("def", tp, true);
+        t = new TextSegment("def", tp);
         s.add(t);
-        t = new TextSegment("ghi", tp, true);
+        t = new TextSegment("ghi", tp);
         segments.add(t);
 
 
@@ -117,12 +117,12 @@ public class SegmentProcessorTest {
         TextProperties tp = new TextProperties.Builder("und").hyphenate(false).build();
         List<Segment> segments = new ArrayList<>();
         List<Segment> expecteds = new ArrayList<>();
-        t = new TextSegment("abc", tp, true);
+        t = new TextSegment("abc", tp);
         segments.add(t);
-        expecteds.add(new TextSegment("abcxdefy", tp, true));
+        expecteds.add(new TextSegment("abcxdefy", tp));
         Style s = new Style("em");
         segments.add(s);
-        t = new TextSegment("def", tp, true);
+        t = new TextSegment("def", tp);
         s.add(t);
         t = new AnchorSegment("ref-id");
         s.add(t);

--- a/test/org/daisy/dotify/formatter/impl/segment/TextSegmentTest.java
+++ b/test/org/daisy/dotify/formatter/impl/segment/TextSegmentTest.java
@@ -16,9 +16,9 @@ public class TextSegmentTest {
    public void testGetLocaleReturnEmptyOptionalIfLocaleIsNull() {
         // Test that verifies that getLocale does not crash if locale is null.
         TextProperties.Builder builder = new TextProperties.Builder(null);
-        TextProperties tp = builder.build();
+        TextProperties tp = builder.markCapitalLetters(false).build();
         String chars = "";
-        TextSegment ts = new TextSegment(chars, tp, false);
+        TextSegment ts = new TextSegment(chars, tp);
         Optional<String> locale = ts.getLocale();
         assertEquals(Optional.empty(), locale);
     }
@@ -27,9 +27,9 @@ public class TextSegmentTest {
     public void testVerifyComparisonWIthOptionals() {
         // Test comparison with Optionals.
         TextProperties.Builder builder = new TextProperties.Builder(null);
-        TextProperties tp = builder.build();
+        TextProperties tp = builder.markCapitalLetters(false).build();
         String chars = "";
-        TextSegment ts = new TextSegment(chars, tp, false);
+        TextSegment ts = new TextSegment(chars, tp);
         Optional<String> locale = ts.getLocale();
         String localeSwe = "sv_SE";
         assertNotEquals(locale, localeSwe);


### PR DESCRIPTION
Hi @bertfrees and @PaulRambags

After reviewing the code for how the hyphenation code is implemented, I realized that it was done with an attribute, and I see no reason why capital letter marks could not be handled the same way.

This pull request adds the functionality of a new attribute for text processing. `mark-capital-letters` could be used to inform the formatter if the text should have capital letter marks.

Please review and comment.

Best regards