### PR TITLE
Fix bugs that can result in endless iterations

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -307,6 +307,30 @@ public class PageSequenceBuilder2 {
             context.getTransitionBuilder().getProperties().getApplicationRange() != ApplicationRange.NONE &&
             transitionContent.isPresent() &&
             transitionContent.get().getType() == TransitionContent.Type.INTERRUPT;
+        if (nextEmpty) {
+            // Return an empty page because the next row should be on a new sheet and we are
+            // currently on the back of a sheet.
+            // Note that we don't update cbl here, so the page after this one will have the same
+            // identity. Luckily it does not matter for SheetIdentity: there can't be two empty
+            // verso pages after each other so every SheetIdentity is still unique.
+            // Also note that we don't call keepTransitionProperties().
+            nextEmpty = false;
+            if (prevCbl != null && interruptContentPresent) {
+                // By calling setNextPageInSequenceEmptyOrAbsent() we tell SheetDataSource
+                // (in the next iteration) two things:
+                // 1. to not use this page's currentBlockLineLocation to look up its
+                //    transitionProperties because that info is not available (so could result in
+                //    CrossReferenceHandler staying dirty forever) and the currentBlockLineLocation
+                //    is not unique.
+                // 2. If the volume must be broken on a sheet that is empty on the back, we prefer
+                //    to put the transition content on the back of the sheet, not on the front.
+                blockContext.getRefs().setNextPageInSequenceEmptyOrAbsent(prevCbl);
+                // Set prevCbl to null so that the command above can not be undone with a
+                // setNextPageDetailsInSequence() in the next nextPage() call.
+                prevCbl = null;
+            }
+            return current;
+        }
         // Store a mapping from the BlockLineLocation of the last line of the page before the
         // previous page to the BlockLineLocation of the last line of the previous page. This info
         // is used (in the next iteration) in SheetDataSource to obtain info about the verso page of
@@ -314,10 +338,6 @@ public class PageSequenceBuilder2 {
         // break the volume after the current page or the next.
         if (prevCbl != null && interruptContentPresent) {
             blockContext.getRefs().setNextPageDetailsInSequence(prevCbl, current.getDetails());
-        }
-        if (nextEmpty) {
-            nextEmpty = false;
-            return current;
         }
         prevCbl = cbl;
 
@@ -621,15 +641,17 @@ public class PageSequenceBuilder2 {
                     BreakBefore nextStart = dataGroups.get(dataGroupsIndex).getBreakBefore();
                     switch (nextStart) {
                         case SHEET:
+                            // next row starts on new sheet
                             if (master.duplex()) {
-                                if (pageCount % 2 == 1) { // on recto page
+                                if (pageCount % 2 == 1) { // we are on a recto page
                                     if (current.hasRows()) {
+                                        // indicate that the next page (the verso page) should be empty
                                         nextEmpty = true;
                                         return current;
                                     } else {
                                         break; // we are already at the beginning of a recto page
                                     }
-                                } else { // on verso page
+                                } else { // we are on a verso page
                                     return current;
                                 }
                             }
@@ -643,6 +665,7 @@ public class PageSequenceBuilder2 {
                             break; // we are already at the beginning of a page
 
                         case PAGE:
+                            // next row starts on new page
                             if (current.hasRows()) {
                                 return current;
                             }

--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -335,10 +335,10 @@ public class PageSequenceBuilder2 {
         // correct under all the assumptions made.
         blockContext = new BlockContext.Builder(blockContext).topOfPage(true).build();
 
-        // while there are more rows in the current block, or there are more blocks...
+        // while there are more rows in the current RowGroupSequence, or there are more RowGroupSequences
         while (dataGroupsIndex < dataGroups.size() || (data != null && !data.isEmpty())) {
             if ((data == null || data.isEmpty()) && dataGroupsIndex < dataGroups.size()) {
-                // pick up next block (as RowGroupSequence)
+                // pick up next RowGroupSequence
                 RowGroupSequence rgs = dataGroups.get(dataGroupsIndex);
                 //TODO: This assumes that all page templates have margin regions that are of the same width
                 BlockContext bc = BlockContext.from(blockContext)

--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -95,7 +95,8 @@ public class PageSequenceBuilder2 {
     private boolean nextEmpty = false;
 
     private BlockLineLocation cbl;
-    private BlockLineLocation prevCbl; // previous value of cbl
+    private BlockLineLocation prevCbl; // value of cbl in effect before the last call to nextPage(),
+                                       // or null if nextPage() has not been called yet
 
     //From view, temporary
     private final int fromIndex;
@@ -318,6 +319,8 @@ public class PageSequenceBuilder2 {
             nextEmpty = false;
             return current;
         }
+        prevCbl = cbl;
+
         // The purpose of this is to prevent supplements from combining with header/footer
         cd.setExtraOverhead(
             current.getPageTemplate().validateAndAnalyzeHeader() +
@@ -567,7 +570,6 @@ public class PageSequenceBuilder2 {
                 if (!head.isEmpty()) {
                     int s = head.size();
                     RowGroup gr = head.get(s - 1);
-                    prevCbl = cbl;
                     cbl = gr.getLineProperties().getBlockLineLocation();
                 }
                 // Add the body rows to the page.

--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -299,17 +299,19 @@ public class PageSequenceBuilder2 {
             boolean wasSplitInSequence,
             boolean isFirst
     ) throws PaginatorException, RestartPaginationException { // pagination must be restarted in
-        // PageStructBuilder.paginateInner
+                                                              // PageStructBuilder.paginateInner
         PageImpl current = newPage(pageNumberOffset);
-        if (
-            prevCbl != null &&
-            // Store a mapping from the BlockLineLocation of the last line of the page before the
-            // previous page to the BlockLineLocation of the last line of the previous page. This
-            // info is used (in the next iteration) in SheetDataSource to obtain info about the
-            // verso page of a sheet when we are on a recto page of that sheet.
+        // whether this is the last page of the volume and a volume transition was provided
+        boolean interruptContentPresent =
+            context.getTransitionBuilder().getProperties().getApplicationRange() != ApplicationRange.NONE &&
             transitionContent.isPresent() &&
-            transitionContent.get().getType() == TransitionContent.Type.INTERRUPT
-        ) {
+            transitionContent.get().getType() == TransitionContent.Type.INTERRUPT;
+        // Store a mapping from the BlockLineLocation of the last line of the page before the
+        // previous page to the BlockLineLocation of the last line of the previous page. This info
+        // is used (in the next iteration) in SheetDataSource to obtain info about the verso page of
+        // a sheet when we are on a recto page of that sheet and we need to determine whether to
+        // break the volume after the current page or the next.
+        if (prevCbl != null && interruptContentPresent) {
             blockContext.getRefs().setNextPageDetailsInSequence(prevCbl, current.getDetails());
         }
         if (nextEmpty) {
@@ -437,7 +439,7 @@ public class PageSequenceBuilder2 {
                 // First find the optimal break point
                 SplitPointSpecification spec;
                 boolean addTransition = true;
-                if (transitionContent.isPresent() && transitionContent.get().getType() == Type.INTERRUPT) {
+                if (interruptContentPresent) {
                     // Subtract the height of the transition text from the available height.
                     // We need to account for the last unit size here (because this is the last unit) instead
                     // of the one below. The transition text may have a smaller row spacing than the last row of
@@ -581,25 +583,20 @@ public class PageSequenceBuilder2 {
                 );
                 // Store info about this volume transition for use in the next iteration (used in SheetDataSource).
                 // No need to do this unless there is an active transition builder.
-                if (context.getTransitionBuilder().getProperties().getApplicationRange() != ApplicationRange.NONE) {
+                if (interruptContentPresent) {
                     // Determine whether there is a block boundary on the page, with enough space
                     // available after this point for sequence-interrupted and any-interrupted.
                     boolean hasBlockBoundary =
                         blockBoundary.isPresent() ?
                         blockBoundary.get() :
                         res.getHead().stream().filter(r -> r.isLastRowGroupInBlock()).findFirst().isPresent();
-                    if (
-                            transitionContent.isPresent() &&
-                                    transitionContent.get().getType() == TransitionContent.Type.INTERRUPT
-                    ) {
-                        bc.getRefs().keepTransitionProperties(
-                                current.getDetails().getPageLocation(),
-                                new TransitionProperties(
-                                        current.getAvoidVolumeBreakAfter(),
-                                        hasBlockBoundary
-                                )
-                        );
-                    }
+                    bc.getRefs().keepTransitionProperties(
+                        current.getDetails().getPageLocation(),
+                        new TransitionProperties(
+                            current.getAvoidVolumeBreakAfter(),
+                            hasBlockBoundary
+                        )
+                    );
                 }
                 // Discard collapsed margins, but retain their properties (identifiers, markers,
                 // keep-with-next-sheets, keep-with-previous-sheets).

--- a/src/org/daisy/dotify/formatter/impl/search/CrossReferenceHandler.java
+++ b/src/org/daisy/dotify/formatter/impl/search/CrossReferenceHandler.java
@@ -384,6 +384,15 @@ public class CrossReferenceHandler {
     }
 
     /**
+     * Indicate that a page is the last one in the sequence or that the next page is empty.
+     *
+     * @param id The BlockLineLocation that identifies the page.
+     */
+    public void setNextPageInSequenceEmptyOrAbsent(BlockLineLocation id) {
+        nextPageDetails.remove(id);
+    }
+
+    /**
      * Returns true if some information has been changed since last use.
      *
      * @return true if some information has been changed, false otherwise

--- a/src/org/daisy/dotify/formatter/impl/search/CrossReferenceHandler.java
+++ b/src/org/daisy/dotify/formatter/impl/search/CrossReferenceHandler.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -26,7 +27,7 @@ public class CrossReferenceHandler {
     private final LookupHandler<BlockAddress, List<Marker>> groupMarkers;
     private final LookupHandler<BlockAddress, List<String>> groupIdentifiers;
     private final LookupHandler<BlockLineLocation, TransitionProperties> transitionProperties;
-    private final LookupHandler<BlockLineLocation, PageDetails> nextPageDetails;
+    private final Map<BlockLineLocation, PageDetails> nextPageDetails;
     private final Map<Integer, Overhead> volumeOverhead;
     private final Map<String, Integer> counters;
     private final SearchInfo searchInfo;
@@ -52,7 +53,7 @@ public class CrossReferenceHandler {
         this.groupMarkers = new LookupHandler<>();
         this.groupIdentifiers = new LookupHandler<>();
         this.transitionProperties = new LookupHandler<>();
-        this.nextPageDetails = new LookupHandler<>();
+        this.nextPageDetails = new HashMap<>();
         this.volumeOverhead = new HashMap<>();
         this.counters = new HashMap<>();
         this.searchInfo = new SearchInfo();
@@ -370,13 +371,14 @@ public class CrossReferenceHandler {
     }
 
     public Optional<PageDetails> getNextPageDetailsInSequence(BlockLineLocation id) {
-        return Optional.ofNullable(nextPageDetails.get(id, null, readOnly));
+        return Optional.ofNullable(nextPageDetails.get(id));
     }
 
     public void setNextPageDetailsInSequence(BlockLineLocation id, PageDetails details) {
         if (readOnly) {
             return;
         }
+        Objects.requireNonNull(details);
         nextPageDetails.put(id, details);
     }
 

--- a/src/org/daisy/dotify/formatter/impl/search/CrossReferenceHandler.java
+++ b/src/org/daisy/dotify/formatter/impl/search/CrossReferenceHandler.java
@@ -370,8 +370,9 @@ public class CrossReferenceHandler {
         return searchInfo.findStartAndMarker(id, spec);
     }
 
-    public Optional<PageDetails> getNextPageDetailsInSequence(BlockLineLocation id) {
-        return Optional.ofNullable(nextPageDetails.get(id));
+    public Optional<BlockLineLocation> getNextPageLocationInSequence(BlockLineLocation id) {
+        PageDetails details = nextPageDetails.get(id);
+        return details != null ? Optional.of(details.getPageLocation()) : Optional.empty();
     }
 
     public void setNextPageDetailsInSequence(BlockLineLocation id, PageDetails details) {

--- a/src/org/daisy/dotify/formatter/impl/search/SheetIdentity.java
+++ b/src/org/daisy/dotify/formatter/impl/search/SheetIdentity.java
@@ -1,16 +1,37 @@
 package org.daisy.dotify.formatter.impl.search;
 
 /**
- * TODO: Write java doc.
+ * Sheet starting at a specific location within a block.
  */
 public class SheetIdentity {
     private final Space space;
     private final Integer volumeIndex;
     private final Integer volumeGroup;
-    private final int sheetIndex;
+    private final BlockLineLocation blockLineLocation;
 
-    public SheetIdentity(Space s, Integer volumeIndex, Integer volumeGroup, int sheetIndex) {
-        this.space = s;
+    /**
+     * Create a SheetIdentity from a BlockLineLocation. The BlockLineLocation points to the last
+     * line of the preceding sheet within the current volume group or pre-/post-content
+     * section. Additional arguments are needed to uniquely identify the sheet when it is the first
+     * of the current volume group or pre-/post-content section.
+     *
+     * @param blockLineLocation location of the last line of the preceding sheet within the current
+     *                          volume group or pre-/post-content section, or null if there is no
+     *                          preceding sheet.
+     * @param space             the space ({@link Space#BODY}, {@link Space#PRE_CONTENT} or {@link
+     *                          Space#POST_CONTENT}).
+     * @param volumeIndex       the volume index if <code>space</code> is {@link Space#PRE_CONTENT}
+     *                          or {@link Space#POST_CONTENT}.
+     * @param volumeGroup       the volume group index if <code>space</code> is
+     *                          {@link Space#BODY}.
+     */
+    public SheetIdentity(
+        BlockLineLocation blockLineLocation,
+        Space space,
+        Integer volumeIndex,
+        Integer volumeGroup
+    ) {
+        this.space = space;
         if (space == Space.BODY) {
             if (volumeIndex != null) {
                 volumeIndex = null;
@@ -25,27 +46,15 @@ public class SheetIdentity {
         }
         this.volumeIndex = volumeIndex;
         this.volumeGroup = volumeGroup;
-        this.sheetIndex = sheetIndex;
-    }
-
-    public Space getSpace() {
-        return space;
-    }
-
-    public Integer getVolumeIndex() {
-        return volumeIndex;
-    }
-
-    public int getSheetIndex() {
-        return sheetIndex;
+        this.blockLineLocation = blockLineLocation;
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((space == null) ? 0 : space.hashCode());
-        result = prime * result + sheetIndex;
+        result = prime * result + (space == null ? 0 : space.hashCode());
+        result = prime * result + (blockLineLocation == null ? 0 : blockLineLocation.hashCode());
         result = prime * result + (volumeIndex == null ? 0 : volumeIndex);
         result = prime * result + (volumeGroup == null ? 0 : volumeGroup);
         return result;
@@ -66,7 +75,11 @@ public class SheetIdentity {
         if (space != other.space) {
             return false;
         }
-        if (sheetIndex != other.sheetIndex) {
+        if (blockLineLocation == null) {
+            if (other.blockLineLocation != null) {
+                return false;
+            }
+        } else if (!blockLineLocation.equals(other.blockLineLocation)) {
             return false;
         }
         if (volumeIndex == null) {
@@ -91,7 +104,7 @@ public class SheetIdentity {
         return "SheetIdentity [space=" + space
                 + (volumeIndex == null ? "" : ", volumeIndex=" + volumeIndex)
                 + (volumeGroup == null ? "" : ", volumeGroup=" + volumeGroup)
-                + ", sheetIndex=" + sheetIndex + "]";
+                + ", blockLineLocation=" + blockLineLocation + "]";
     }
 
 }

--- a/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
@@ -15,7 +15,6 @@ import org.daisy.dotify.formatter.impl.page.RestartPaginationException;
 import org.daisy.dotify.formatter.impl.search.BlockLineLocation;
 import org.daisy.dotify.formatter.impl.search.DefaultContext;
 import org.daisy.dotify.formatter.impl.search.DocumentSpace;
-import org.daisy.dotify.formatter.impl.search.PageDetails;
 import org.daisy.dotify.formatter.impl.search.SequenceId;
 import org.daisy.dotify.formatter.impl.search.SheetIdentity;
 import org.daisy.dotify.formatter.impl.search.TransitionProperties;
@@ -302,21 +301,20 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                         ) {
                             // This id is the same id as the one created below in the call to nextPage
                             BlockLineLocation thisPageId = psb.currentBlockLineLocation();
-                            // This gets the page details for the next page in this sequence (if any)
-                            Optional<PageDetails> next = thisPageId != null
-                                ? rcontext.getRefs().getNextPageDetailsInSequence(thisPageId)
+                            // This gets the page location for the next page in this sequence (if any)
+                            Optional<BlockLineLocation> nextPageId = thisPageId != null
+                                ? rcontext.getRefs().getNextPageLocationInSequence(thisPageId)
                                 : Optional.empty();
-                            // If there is a page details in this sequence and volume break is preferred on this page
-                            if (next.isPresent()) {
+                            if (nextPageId.isPresent()) {
+                                // there is a next page in this sequence and a volume break is preferred on this page
                                 Optional<TransitionProperties> st1 = rcontext.getRefs().getTransitionProperties(
-                                        thisPageId
+                                    thisPageId
                                 );
                                 TransitionProperties p = st1.orElse(TransitionProperties.empty());
                                 double v1 = p.getVolumeKeepPriority()
                                     .orElse(10) + (p.hasBlockBoundary() ? 0.5 : 0);
-
                                 Optional<TransitionProperties> st2 = rcontext.getRefs().getTransitionProperties(
-                                    next.get().getPageLocation()
+                                    nextPageId.get()
                                 );
                                 p = st2.orElse(TransitionProperties.empty());
                                 double v2 = p.getVolumeKeepPriority()

--- a/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
@@ -12,7 +12,6 @@ import org.daisy.dotify.formatter.impl.page.BlockSequence;
 import org.daisy.dotify.formatter.impl.page.PageImpl;
 import org.daisy.dotify.formatter.impl.page.PageSequenceBuilder2;
 import org.daisy.dotify.formatter.impl.page.RestartPaginationException;
-import org.daisy.dotify.formatter.impl.search.BlockAddress;
 import org.daisy.dotify.formatter.impl.search.BlockLineLocation;
 import org.daisy.dotify.formatter.impl.search.DefaultContext;
 import org.daisy.dotify.formatter.impl.search.DocumentSpace;
@@ -24,6 +23,7 @@ import org.daisy.dotify.formatter.impl.search.VolumeKeepPriority;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,14 +54,14 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
     private DefaultContext rcontext;
     private final Integer volumeGroup;
     private final List<BlockSequence> seqsIterator;
-    private final int sheetOffset;
     //Local state
     private int seqsIndex;
     private SequenceId seqId;
     private PageSequenceBuilder2 psb;
     private int psbCurStartIndex; // index of first page of current psb in current volume
     private SectionProperties sectionProperties;
-    private int sheetIndex;
+    private int sheetIndex; // sheets created from current sequence or being created
+    private LinkedList<SheetIdentity> previousSheets; // all sheets created from the current sequence
     private int pageIndex;
     private String counter;
     private int initialPageOffset;
@@ -71,8 +71,7 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
     private boolean isFirst;
     private boolean wasSplitInsideSequence;
     private boolean volumeEnded;
-    //Output buffer
-    private List<Sheet> sheetBuffer;
+    private List<Sheet> sheetBuffer; // output buffer
 
     public SheetDataSource(
         PageCounter pageCounter,
@@ -88,13 +87,13 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
         this.seqsIterator = seqsIterator;
         this.sheetBuffer = new ArrayList<>();
         this.volBreakAllowed = true;
-        this.sheetOffset = 0;
         this.seqsIndex = 0;
         this.seqId = null;
         this.psb = null;
         this.psbCurStartIndex = 0;
         this.sectionProperties = null;
         this.sheetIndex = 0;
+        this.previousSheets = new LinkedList<>();
         this.pageIndex = 0;
         this.counter = null;
         this.initialPageOffset = 0;
@@ -130,9 +129,9 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
         this.psb = tail ? template.psb : PageSequenceBuilder2.copyUnlessNull(template.psb);
         this.psbCurStartIndex = template.psbCurStartIndex;
         this.sectionProperties = template.sectionProperties;
-        this.sheetOffset = template.sheetOffset + offset;
         this.sheetIndex = template.sheetIndex;
         this.pageIndex = template.pageIndex;
+        this.previousSheets = new LinkedList<>(template.previousSheets);
         if (template.sheetBuffer.size() > offset) {
             this.sheetBuffer = new ArrayList<>(template.sheetBuffer.subList(offset, template.sheetBuffer.size()));
         } else {
@@ -202,8 +201,8 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
      * @return returns true if the index element was available, false otherwise
      */
     private boolean ensureBuffer(int index) {
-        Sheet.Builder s = null;
-        SheetIdentity si = null;
+        Sheet.Builder s = null; // sheet currently being built
+        SheetIdentity si = null; // sheet currently being built
         while (index < 0 || sheetBuffer.size() < index) {
             // this happens when a new volume is started
             if (updateCounter) {
@@ -221,6 +220,7 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                 if (s != null) {
                     //Last page in the sequence doesn't need volume keep priority
                     sheetBuffer.add(s.build());
+                    previousSheets.push(si);
                     s = null;
                     continue;
                 }
@@ -246,9 +246,6 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                     new DocumentSpace(rcontext.getSpace(), rcontext.getCurrentVolume()),
                     volumeGroup
                 );
-                BlockLineLocation cbl = psb != null ?
-                    psb.currentBlockLineLocation() :
-                    new BlockLineLocation(new BlockAddress(-1, -1), -1);
                 psbCurStartIndex = pageCounter.getPageCount();
                 psb = new PageSequenceBuilder2(
                     psbCurStartIndex,
@@ -258,20 +255,23 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                     context,
                     rcontext,
                     seqId,
-                    cbl
+                    psb != null ? psb.currentBlockLineLocation() : null
                 );
                 sectionProperties = bs.getLayoutMaster().newSectionProperties();
                 s = null;
                 si = null;
                 sheetIndex = 0;
                 pageIndex = 0;
+                if (!previousSheets.isEmpty()) {
+                    previousSheets = new LinkedList<>();
+                }
             }
             int currentSize = sheetBuffer.size();
             while (psb.hasNext() && currentSize == sheetBuffer.size()) {
                 if (!sectionProperties.duplex() || pageIndex % 2 == 0 || volumeEnded || s == null) {
                     if (s != null) {
-                        Sheet r = s.build();
-                        sheetBuffer.add(r);
+                        sheetBuffer.add(s.build());
+                        previousSheets.push(si);
                         s = null;
                         if (volumeEnded) {
                             pageIndex += pageIndex % 2 == 1 ? 1 : 0;
@@ -283,10 +283,10 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                     volBreakAllowed = true;
                     s = new Sheet.Builder(sectionProperties);
                     si = new SheetIdentity(
-                            rcontext.getSpace(),
-                            rcontext.getCurrentVolume(),
-                            volumeGroup,
-                            sheetBuffer.size() + sheetOffset
+                        psb.currentBlockLineLocation(),
+                        rcontext.getSpace(),
+                        rcontext.getCurrentVolume(),
+                        volumeGroup
                     );
                     sheetIndex++;
                 }
@@ -303,7 +303,9 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                             // This id is the same id as the one created below in the call to nextPage
                             BlockLineLocation thisPageId = psb.currentBlockLineLocation();
                             // This gets the page details for the next page in this sequence (if any)
-                            Optional<PageDetails> next = rcontext.getRefs().getNextPageDetailsInSequence(thisPageId);
+                            Optional<PageDetails> next = thisPageId != null
+                                ? rcontext.getRefs().getNextPageDetailsInSequence(thisPageId)
+                                : Optional.empty();
                             // If there is a page details in this sequence and volume break is preferred on this page
                             if (next.isPresent()) {
                                 Optional<TransitionProperties> st1 = rcontext.getRefs().getTransitionProperties(
@@ -379,12 +381,7 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
                     }
                     s.breakable(br);
                 }
-
-                setPreviousSheet(
-                    si.getSheetIndex() - 1,
-                    Math.min(p.keepPreviousSheets(), sheetIndex - 1),
-                    rcontext
-                );
+                keepWithPreviousSheets(previousSheets, p.keepPreviousSheets(), rcontext);
                 volBreakAllowed &= p.allowsVolumeBreak();
                 if (!sectionProperties.duplex() || pageIndex % 2 == 1 || volumeEnded) {
                     rcontext.getRefs().keepBreakable(si, volBreakAllowed);
@@ -420,13 +417,14 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
         return true;
     }
 
-    private void setPreviousSheet(int start, int p, DefaultContext rcontext) {
-        int i = 0;
-        //TODO: simplify this?
-        for (int x = start; i < p && x > 0; x--) {
-            SheetIdentity si = new SheetIdentity(rcontext.getSpace(), rcontext.getCurrentVolume(), volumeGroup, x);
-            rcontext.getRefs().keepBreakable(si, false);
-            i++;
+    private static void keepWithPreviousSheets(List<SheetIdentity> previousSheets, int n, DefaultContext rcontext) {
+        for (SheetIdentity s : previousSheets) {
+            if (n > 0) {
+                rcontext.getRefs().keepBreakable(s, false);
+                n--;
+            } else {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
There are three main commits in this PR that fix three different bugs, all related to the CrossReferenceHandler.

- 4d88f38: Uses BlockLineLocation instead of SheetIdentity to store "breakable" info, for the same reason why we're using BlockLineLocation for the "volume transition properties" info (since commit d386effaf64890cf587911ebdd73).
- a98cc81: Fixes a bug that could cause endless iterations when the last sheet of a volume had a vertically positioned block on it.
- a55be8b: Fixes a bug that could cause endless iterations when the volume was split at a sheet with an empty back.

The first and the last I discovered the hard way, because Dotify would fail to convert certain books. The second one is something I discovered in the code while looking for the two other bugs.

The 4 other commits are small refactorings are fixes to comments.

@kalaspuffar @PaulRambags Please have a look. Hope you can make sense of it. I've tried to explain well in the code why certains things are done, but let me know if anything needs more clarification.